### PR TITLE
Add usefull algorithms to decode html entities to utf-8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ ADD_LIBRARY(entities STATIC
 	entities.c
 )
 
-
 # Build unit cases
 ADD_EXECUTABLE(test-entities
 	t-entities.c

--- a/entities.c
+++ b/entities.c
@@ -427,7 +427,7 @@ static bool parse_entity_wo_unsafe_symbols(
 			{
 				// rollback
 				size_t html_entities_len = (size_t)(end - current) + 1;
-				strncpy(*to, current, html_entities_len);
+				memmove(*to, current, html_entities_len);
 				utf8_symb_len = html_entities_len;
 				break;
 			}
@@ -629,7 +629,7 @@ static bool parse_entity_wo_unsafe_symbols_n(
 			{
 				// rollback
 				size_t html_entities_len = (size_t)(end - current) + 1;
-				strncpy(*to, current, html_entities_len);
+				memmove(*to, current, html_entities_len);
 				utf8_symb_len = html_entities_len;
 				break;
 			}
@@ -638,7 +638,7 @@ static bool parse_entity_wo_unsafe_symbols_n(
 		*to += utf8_symb_len;
 		*from = end + 1;
 
-		*curr_size -= end - current;
+		*curr_size -= end - current + 1;
 		return 1;
 	}
 
@@ -653,7 +653,7 @@ static bool parse_entity_wo_unsafe_symbols_n(
 
 	*to += len;
 	*from = end + 1;
-	*curr_size -= end - current;
+	*curr_size -= end - current + 1;
 
 	return 1;
 }
@@ -661,7 +661,7 @@ static bool parse_entity_wo_unsafe_symbols_n(
 size_t decode_html_entities_utf8_wo_unsafe_symbols_n(char *dest, const char *src, 
 	size_t src_size, const char* unsafe_symbs)
 {
-	if(!src) src = dest;
+	if(!src) src = dest; //return 0;
 
 	char *to = dest;
 	const char *from = src;

--- a/entities.c
+++ b/entities.c
@@ -8,7 +8,6 @@
 #include "entities.h"
 
 #include <errno.h>
-#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h> /* LONG_MAX */
@@ -327,7 +326,7 @@ static size_t putc_utf8(unsigned long cp, char *buffer)
 	return 0;
 }
 
-static bool parse_entity(
+static _Bool parse_entity(
 	const char *current, char **to, const char **from)
 {
 	const char *end = strchr(current, ';');
@@ -337,13 +336,13 @@ static bool parse_entity(
 	{
 		char *tail = NULL;
 		int errno_save = errno;
-		bool hex = current[2] == 'x' || current[2] == 'X';
+		_Bool hex = current[2] == 'x' || current[2] == 'X';
 
 		errno = 0;
 		unsigned long cp = strtoul(
 			current + (hex ? 3 : 2), &tail, hex ? 16 : 10);
 
-		bool fail = errno || tail != end || cp > UNICODE_MAX;
+		_Bool fail = errno || tail != end || cp > UNICODE_MAX;
 		errno = errno_save;
 		if(fail) return 0;
 
@@ -395,7 +394,7 @@ size_t decode_html_entities_utf8(char *dest, const char *src)
 }
 
 
-static bool parse_entity_wo_unsafe_symbols(
+static _Bool parse_entity_wo_unsafe_symbols(
 	const char *current, char **to, const char **from,
 	const char* unsafe_symbs)
 {
@@ -406,13 +405,13 @@ static bool parse_entity_wo_unsafe_symbols(
 	{
 		char *tail = NULL;
 		int errno_save = errno;
-		bool hex = current[2] == 'x' || current[2] == 'X';
+		_Bool hex = current[2] == 'x' || current[2] == 'X';
 
 		errno = 0;
 		unsigned long cp = strtoul(
 			current + (hex ? 3 : 2), &tail, hex ? 16 : 10);
 
-		bool fail = errno || tail != end || cp > UNICODE_MAX;
+		_Bool fail = errno || tail != end || cp > UNICODE_MAX;
 		errno = errno_save;
 		if(fail) return 0;
 
@@ -451,10 +450,6 @@ static bool parse_entity_wo_unsafe_symbols(
 	return 1;
 }
 
-/**
- * @param unsafe_symbs strings of unwanted symbs 
- * delimited '\0'. Ends by double '\0' 
- * */
 size_t decode_html_entities_utf8_wo_unsafe_symbols(char *dest, const char *src, 
 	const char* unsafe_symbs) 
 {
@@ -505,17 +500,17 @@ static int strcmp_n(const char *lhs, size_t lhs_len, const char *rhs)
 	return lhs_len == 0 ? 0 : lhs[i] - rhs[i];
 }
 
-static size_t c_is_shit = 0;
+static size_t clang_is_good = 0;
 
 static int cmp_n(const void *key, const void *value)
 {
-	return strcmp_n((const char *)key, c_is_shit, 
+	return strcmp_n((const char *)key, clang_is_good, 
 		(const char *)value);
 }
 
 static const char *get_named_entity_n(const char *name, size_t name_len)
 {
-	c_is_shit = name_len;
+	clang_is_good = name_len;
 	const char *const *entity = (const char *const *)bsearch(name,
 		NAMED_ENTITIES, sizeof NAMED_ENTITIES / sizeof *NAMED_ENTITIES,
 		sizeof *NAMED_ENTITIES, cmp_n);
@@ -594,7 +589,7 @@ strtoul_n(const char *restrict nptr, size_t nptr_len, char **restrict endptr, in
     return (unsigned long)n;
 }
 
-static bool parse_entity_wo_unsafe_symbols_n(
+static _Bool parse_entity_wo_unsafe_symbols_n(
 	const char *current, size_t* curr_size,
 	char **to, const char **from,
 	const char* unsafe_symbs)
@@ -602,19 +597,19 @@ static bool parse_entity_wo_unsafe_symbols_n(
 	const char *end = strchr_n(current, *curr_size, ';');
 	if(!end) return 0;
 
-	// *curr_size should be more than 3 (start symb, # and)
+	// *curr_size should be more than 3 (start symb, # and ;)
 	size_t entity_len = (end - current);
 	if(entity_len > 3 && current[1] == '#')
 	{
 		char *tail = NULL;
 		int errno_save = errno;
-		bool hex = entity_len > 4 && (current[2] == 'x' || current[2] == 'X');
+		_Bool hex = entity_len > 4 && (current[2] == 'x' || current[2] == 'X');
 
 		errno = 0;
 		unsigned long cp = strtoul_n(
 			current + (hex ? 3 : 2), *curr_size - (hex ? 3 : 2), &tail, hex ? 16 : 10);
 
-		bool fail = errno || tail != end || cp > UNICODE_MAX;
+		_Bool fail = errno || tail != end || cp > UNICODE_MAX;
 		errno = errno_save;
 
 
@@ -645,7 +640,7 @@ static bool parse_entity_wo_unsafe_symbols_n(
 	if (*curr_size < 2)	
 		return 0;
 
-	const char *entity = get_named_entity_n(&current[1], *curr_size - 1); // dangerous
+	const char *entity = get_named_entity_n(&current[1], *curr_size - 1);
 	if(!entity) return 0;
 
 	size_t len = strlen(entity);
@@ -661,7 +656,7 @@ static bool parse_entity_wo_unsafe_symbols_n(
 size_t decode_html_entities_utf8_wo_unsafe_symbols_n(char *dest, const char *src, 
 	size_t src_size, const char* unsafe_symbs)
 {
-	if(!src) src = dest; //return 0;
+	if(!src) src = dest;
 
 	char *to = dest;
 	const char *from = src;
@@ -676,14 +671,13 @@ size_t decode_html_entities_utf8_wo_unsafe_symbols_n(char *dest, const char *src
 			continue;
 
 		from = current;
-		src_size -= current - from; // move of from buffer
+		src_size -= current - from;
 		*to++ = *from++;
 		src_size -= 1;
 	}
 
 	memmove(to, from, src_size);
 	to += src_size;
-	// *to = 0;
 
 	return (size_t)(to - dest);
 }

--- a/entities.c
+++ b/entities.c
@@ -510,7 +510,7 @@ static size_t c_is_shit = 0;
 static int cmp_n(const void *key, const void *value)
 {
 	return strcmp_n((const char *)key, c_is_shit, 
-		(const char *const *)value);
+		(const char *)value);
 }
 
 static const char *get_named_entity_n(const char *name, size_t name_len)
@@ -617,8 +617,6 @@ static bool parse_entity_wo_unsafe_symbols_n(
 		bool fail = errno || tail != end || cp > UNICODE_MAX;
 		errno = errno_save;
 
-		// maybe error with tail
-		*curr_size -= (tail + 1) - current; // start `symb', `#' and `value'
 
 		if(fail) return 0;
 
@@ -639,8 +637,8 @@ static bool parse_entity_wo_unsafe_symbols_n(
 
 		*to += utf8_symb_len;
 		*from = end + 1;
-		--curr_size;
 
+		*curr_size -= end - current;
 		return 1;
 	}
 
@@ -654,9 +652,8 @@ static bool parse_entity_wo_unsafe_symbols_n(
 	memcpy(*to, entity, len);
 
 	*to += len;
-
-	*curr_size -= (end + 1) - *from;
 	*from = end + 1;
+	*curr_size -= end - current;
 
 	return 1;
 }
@@ -679,13 +676,14 @@ size_t decode_html_entities_utf8_wo_unsafe_symbols_n(char *dest, const char *src
 			continue;
 
 		from = current;
+		src_size -= current - from; // move of from buffer
 		*to++ = *from++;
 		src_size -= 1;
 	}
 
 	memmove(to, from, src_size);
 	to += src_size;
-	*to = 0;
+	// *to = 0;
 
 	return (size_t)(to - dest);
 }

--- a/entities.h
+++ b/entities.h
@@ -28,5 +28,18 @@ extern size_t decode_html_entities_utf8(char *dest, const char *src);
 /* extern */ size_t decode_html_entities_utf8_wo_unsafe_symbols(char *dest, const char *src, 
 	const char* unsafe_symbs);
 
+
+/**
+ * 
+ * 
+ * */
+size_t decode_html_entities_utf8_wo_unsafe_symbols_n(char *dest, const char *src, 
+	size_t src_size, const char* unsafe_symbs);
+
+
+// for testing 
+// unsigned long strtoul_n(const char *restrict nptr, size_t nptr_len, 
+	// char **restrict endptr, int base);
+
 #endif
 

--- a/entities.h
+++ b/entities.h
@@ -20,5 +20,13 @@ extern size_t decode_html_entities_utf8(char *dest, const char *src);
 	The function returns the length of the decoded string.
 */
 
+
+/**
+ * @param unsafe_symbs strings of unwanted symbs 
+ * delimited '\0'. Ends by double '\0' 
+ * */
+/* extern */ size_t decode_html_entities_utf8_wo_unsafe_symbols(char *dest, const char *src, 
+	const char* unsafe_symbs);
+
 #endif
 

--- a/entities.h
+++ b/entities.h
@@ -17,29 +17,23 @@ extern size_t decode_html_entities_utf8(char *dest, const char *src);
 	If <src> is <NULL>, input will be taken from <dest>, decoding
 	the entities in-place.
 
-	The function returns the length of the decoded string.
+	The function returns the size of the decoded string.
 */
 
-
-/**
- * @param unsafe_symbs strings of unwanted symbs 
- * delimited '\0'. Ends by double '\0' 
- * */
-/* extern */ size_t decode_html_entities_utf8_wo_unsafe_symbols(char *dest, const char *src, 
+extern size_t decode_html_entities_utf8_wo_unsafe_symbols(char *dest, const char *src, 
 	const char* unsafe_symbs);
+/*	Takes one more params <unsafe_symbs> string delimited '\0' of anscii characters 
+  	that prevented to decode. Ends by double '\0'
 
+*/
 
-/**
- * 
- * 
- * */
-size_t decode_html_entities_utf8_wo_unsafe_symbols_n(char *dest, const char *src, 
+extern size_t decode_html_entities_utf8_wo_unsafe_symbols_n(char *dest, const char *src, 
 	size_t src_size, const char* unsafe_symbs);
+/*	Takes one more params <src_size> that indicated 
+	how many characters must be decode i.e. size of <src>
 
+	<src> may be not null terminated!
+*/
 
-// for testing 
-// unsigned long strtoul_n(const char *restrict nptr, size_t nptr_len, 
-	// char **restrict endptr, int base);
-
-#endif
+#endif // DECODE_HTML_ENTITIES_UTF8_
 

--- a/t-entities.c
+++ b/t-entities.c
@@ -67,16 +67,16 @@ int main(void)
 		char not_null_term_buf[buf_len];
 
 		size_t temp_buf_true_len = decode_html_entities_utf8_wo_unsafe_symbols_n(not_null_term_buf, INPUT, buf_len, "/\0>\0<\0!\0-\0\0");
-		printf("%d %.*s\n", (int)temp_buf_true_len, temp_buf_true_len, not_null_term_buf);
-		// assert(temp_buf_true_len == sizeof SAMPLE);
-		// assert(strncmp(not_null_term_buf, SAMPLE, temp_buf_true_len) == 0);
+		// printf("%d %.*s\n", (int)temp_buf_true_len, temp_buf_true_len, not_null_term_buf);
+		assert(temp_buf_true_len == sizeof SAMPLE - 1);
+		assert(strncmp(not_null_term_buf, SAMPLE, temp_buf_true_len) == 0);
 	}
 
 	{
 		static const char SAMPLE[] = "&#-2;&#1234567890ABCDEFGHJCLMNOP123456789;";
 		// do not convert symbols /, >, <, -, and ! to prevent xss
 		static const char INPUT[] = "&#-2;&#1234567890ABCDEFGHJCLMNOP123456789;"; // >
-		const size_t buf_len = sizeof INPUT - 1; // w/o null terminator
+		size_t buf_len = sizeof INPUT - 1; // w/o null terminator
 		char not_null_term_buf[buf_len];
 
 		size_t temp_buf_true_len = decode_html_entities_utf8_wo_unsafe_symbols_n(not_null_term_buf, INPUT, buf_len, "/\0>\0<\0!\0-\0\0");
@@ -84,6 +84,25 @@ int main(void)
 		assert(temp_buf_true_len == sizeof SAMPLE - 1);
 		assert(strncmp(not_null_term_buf, SAMPLE, temp_buf_true_len) == 0);
 	}
+
+	{
+		char INPUT[] = "";
+
+		assert(decode_html_entities_utf8_wo_unsafe_symbols_n(INPUT, NULL, 0, "/\0>\0<\0!\0-\0\0") == 0);
+	}
+
+
+	{
+		char INPUT[] = "&#;&#1055;&#62;&#1072;&#1074;&#1077;&#1083;&#62;";
+
+		size_t proccessed = decode_html_entities_utf8_wo_unsafe_symbols_n(INPUT, NULL, sizeof INPUT - 1, "/\0>\0<\0!\0-\0\0");
+		// printf("%d %.*s", proccessed, proccessed, INPUT);
+		// printf("%d", sizeof("&#62;П&#62;авел&#62;") - 1);
+		assert(proccessed == sizeof("&#;П&#62;авел&#62;") - 1);
+		assert(strncmp(INPUT, "&#;П&#62;авел&#62;", proccessed) == 0);
+
+	}
+
 
 	fprintf(stdout, "All tests passed :-)\n");
 	return EXIT_SUCCESS;

--- a/t-entities.c
+++ b/t-entities.c
@@ -59,30 +59,30 @@ int main(void)
 		assert(strcmp(buffer, SAMPLE) == 0);
 	}
 
-
 	{
-		// static const char SAMPLE[] = "123123123123123123123123123123";
-		// static const char SAMPLE_h[] = "AAB123";
-		// assert(strtoul_n(SAMPLE, 0, NULL, 10) == 0);
-		// assert(strtoul_n(SAMPLE, 3, NULL, 10) == 123);
-		// assert(strtoul_n(SAMPLE, 4, NULL, 10) == 1231);
-		// assert(strtoul_n(SAMPLE, 5, NULL, 10) == 12312);
-		// assert(strtoul_n(SAMPLE, 6, NULL, 10) == 123123);
-		// assert(strtoul_n(SAMPLE, 20, NULL, 10) == LONG_MAX); // overflow
-		// assert(strncmp(buffer, SAMPLE, sizeof SAMPLE) == 0);
-	}
-
-	{
-		static const char SAMPLE[] = "&#62;П";
+		static const char SAMPLE[] = "&#;П";
 		// do not convert symbols /, >, <, -, and ! to prevent xss
 		static const char INPUT[] = "&#;&#1055;&#62;&#1072;&#1074;&#1077;&#1083;&#62;"; // >
 		const size_t buf_len = 10; // "&#;" -- bad string
 		char not_null_term_buf[buf_len];
-		// assert(decode_html_entities_utf8_wo_unsafe_symbols_n(buffer, INPUT, 17, "/\0>\0<\0!\0-\0\0") == sizeof SAMPLE - 1);
+
 		size_t temp_buf_true_len = decode_html_entities_utf8_wo_unsafe_symbols_n(not_null_term_buf, INPUT, buf_len, "/\0>\0<\0!\0-\0\0");
-		printf("len = %d %.*s\n", temp_buf_true_len, temp_buf_true_len, not_null_term_buf);
-		not_null_term_buf[buf_len - 1] = 0;
-		// assert(strncmp(buffer, SAMPLE, sizeof SAMPLE) == 0);
+		printf("%d %.*s\n", (int)temp_buf_true_len, temp_buf_true_len, not_null_term_buf);
+		// assert(temp_buf_true_len == sizeof SAMPLE);
+		// assert(strncmp(not_null_term_buf, SAMPLE, temp_buf_true_len) == 0);
+	}
+
+	{
+		static const char SAMPLE[] = "&#-2;&#1234567890ABCDEFGHJCLMNOP123456789;";
+		// do not convert symbols /, >, <, -, and ! to prevent xss
+		static const char INPUT[] = "&#-2;&#1234567890ABCDEFGHJCLMNOP123456789;"; // >
+		const size_t buf_len = sizeof INPUT - 1; // w/o null terminator
+		char not_null_term_buf[buf_len];
+
+		size_t temp_buf_true_len = decode_html_entities_utf8_wo_unsafe_symbols_n(not_null_term_buf, INPUT, buf_len, "/\0>\0<\0!\0-\0\0");
+		// printf("%.*s\n", temp_buf_true_len, not_null_term_buf);
+		assert(temp_buf_true_len == sizeof SAMPLE - 1);
+		assert(strncmp(not_null_term_buf, SAMPLE, temp_buf_true_len) == 0);
 	}
 
 	fprintf(stdout, "All tests passed :-)\n");

--- a/t-entities.c
+++ b/t-entities.c
@@ -39,8 +39,6 @@ int main(void)
 
 
 	{
-=======
->>>>>>> 70e7f373d92f7a92beedb155bda0946297795545
 		static const char SAMPLE[] = "&#62;П&#62;авел&#62;";
 		// do not convert symbols /, >, <, -, and ! to prevent xss
 		static const char INPUT[] = "&#62;&#1055;&#62;&#1072;&#1074;&#1077;&#1083;&#62;"; // >

--- a/t-entities.c
+++ b/t-entities.c
@@ -12,9 +12,12 @@
 
 #undef NDEBUG
 #include <assert.h>
+#include <locale.h>
 
 int main(void)
 {
+	setlocale(LC_ALL, "");
+
 	{
 		static const char SAMPLE[] = "Christoph Gärtner";
 		static char buffer[] = "Christoph G&auml;rtner";
@@ -23,12 +26,27 @@ int main(void)
 	}
 
 	{
-		static const char SAMPLE[] = "test@example.org";
-		static const char INPUT[] = "test&#x40;example.org";
+		static const char SAMPLE[] = "Павел Сергеевич Прокопьев";
+		// do not convert symbols /, >, <, -, and ! to prevent xss
+		static const char INPUT[] = "&#1055;&#1072;&#1074;&#1077;&#1083; &#1057;&#1077;&#1088;&#1075;&#1077;&#1077;&#1074;&#1080;&#1095; &#1055;&#1088;&#1086;&#1082;&#1086;&#1087;&#1100;&#1077;&#1074;";
 		static char buffer[sizeof INPUT];
 		assert(decode_html_entities_utf8(buffer, INPUT) == sizeof SAMPLE - 1);
+		// decode_html_entities_utf8(buffer, INPUT);
+		// printf("%s\n", buffer);
 		assert(strcmp(buffer, SAMPLE) == 0);
 	}
+
+
+	{
+		static const char SAMPLE[] = "&#62;П&#62;авел&#62;";
+		// do not convert symbols /, >, <, -, and ! to prevent xss
+		static const char INPUT[] = "&#62;&#1055;&#62;&#1072;&#1074;&#1077;&#1083;&#62;"; // >
+		static char buffer[sizeof INPUT];
+		assert(decode_html_entities_utf8_wo_unsafe_symbols(buffer, INPUT, "/\0>\0<\0!\0-\0\0") == sizeof SAMPLE - 1);
+		// decode_html_entities_utf8_wo_unsafe(buffer, INPUT); printf("%s", buffer);
+		assert(strcmp(buffer, SAMPLE) == 0);
+	}
+
 
 	fprintf(stdout, "All tests passed :-)\n");
 	return EXIT_SUCCESS;

--- a/t-entities.c
+++ b/t-entities.c
@@ -26,18 +26,6 @@ int main(void)
 	}
 
 	{
-		static const char SAMPLE[] = "Павел Сергеевич Прокопьев";
-		// do not convert symbols /, >, <, -, and ! to prevent xss
-		static const char INPUT[] = "&#1055;&#1072;&#1074;&#1077;&#1083; &#1057;&#1077;&#1088;&#1075;&#1077;&#1077;&#1074;&#1080;&#1095; &#1055;&#1088;&#1086;&#1082;&#1086;&#1087;&#1100;&#1077;&#1074;";
-		static char buffer[sizeof INPUT];
-		assert(decode_html_entities_utf8(buffer, INPUT) == sizeof SAMPLE - 1);
-		// decode_html_entities_utf8(buffer, INPUT);
-		// printf("%s\n", buffer);
-		assert(strcmp(buffer, SAMPLE) == 0);
-	}
-
-
-	{
 		static const char SAMPLE[] = "&#62;П&#62;авел&#62;";
 		// do not convert symbols /, >, <, -, and ! to prevent xss
 		static const char INPUT[] = "&#62;&#1055;&#62;&#1072;&#1074;&#1077;&#1083;&#62;"; // >

--- a/t-entities.c
+++ b/t-entities.c
@@ -13,6 +13,7 @@
 #undef NDEBUG
 #include <assert.h>
 #include <locale.h>
+#include <limits.h>
 
 int main(void)
 {
@@ -25,14 +26,14 @@ int main(void)
 		assert(strcmp(buffer, SAMPLE) == 0);
 	}
 
+
 	{
-		static const char SAMPLE[] = "Павел Сергеевич Прокопьев";
+		static const char SAMPLE[] = "&#60;&#33;&#45;&#45; i want to inject xss script &#45;&#45;&#62;alert(\"nice\")";
 		// do not convert symbols /, >, <, -, and ! to prevent xss
-		static const char INPUT[] = "&#1055;&#1072;&#1074;&#1077;&#1083; &#1057;&#1077;&#1088;&#1075;&#1077;&#1077;&#1074;&#1080;&#1095; &#1055;&#1088;&#1086;&#1082;&#1086;&#1087;&#1100;&#1077;&#1074;";
+		static const char INPUT[] = "&#60;&#33;&#45;&#45;&#32;&#105;&#32;&#119;&#97;&#110;&#116;&#32;&#116;&#111;&#32;&#105;&#110;&#106;&#101;&#99;&#116;&#32;&#120;&#115;&#115;&#32;&#115;&#99;&#114;&#105;&#112;&#116;&#32;&#45;&#45;&#62;&#97;&#108;&#101;&#114;&#116;&#40;&#34;&#110;&#105;&#99;&#101;&#34;&#41;"; // >
 		static char buffer[sizeof INPUT];
-		assert(decode_html_entities_utf8(buffer, INPUT) == sizeof SAMPLE - 1);
-		// decode_html_entities_utf8(buffer, INPUT);
-		// printf("%s\n", buffer);
+		assert(decode_html_entities_utf8_wo_unsafe_symbols(buffer, INPUT, "/\0>\0<\0!\0-\0\0") == sizeof SAMPLE - 1);
+		// decode_html_entities_utf8_wo_unsafe(buffer, INPUT); printf("%s", buffer);
 		assert(strcmp(buffer, SAMPLE) == 0);
 	}
 
@@ -47,6 +48,42 @@ int main(void)
 		assert(strcmp(buffer, SAMPLE) == 0);
 	}
 
+
+	{
+		static const char SAMPLE[] = "&#33;&#62;&#62;&#60;&#45;&#45;&#60;&#62;&#60;&#62;&#33;&#45;&#47;&#62;&#60;&#47;&#45;&#45;&#62;&#33;&#60;&#33;&#45;&#45; &#45;&#45;&#62;";
+		// do not convert symbols /, >, <, -, and ! to prevent xss
+		static const char INPUT[] = "&#33;&#62;&#62;&#60;&#45;&#45;&#60;&#62;&#60;&#62;&#33;&#45;&#47;&#62;&#60;&#47;&#45;&#45;&#62;&#33;&#60;&#33;&#45;&#45;&#32;&#45;&#45;&#62;"; // >
+		static char buffer[sizeof INPUT];
+		assert(decode_html_entities_utf8_wo_unsafe_symbols(buffer, INPUT, "/\0>\0<\0!\0-\0\0") == sizeof SAMPLE - 1);
+		// decode_html_entities_utf8_wo_unsafe(buffer, INPUT); printf("%s", buffer);
+		assert(strcmp(buffer, SAMPLE) == 0);
+	}
+
+
+	{
+		// static const char SAMPLE[] = "123123123123123123123123123123";
+		// static const char SAMPLE_h[] = "AAB123";
+		// assert(strtoul_n(SAMPLE, 0, NULL, 10) == 0);
+		// assert(strtoul_n(SAMPLE, 3, NULL, 10) == 123);
+		// assert(strtoul_n(SAMPLE, 4, NULL, 10) == 1231);
+		// assert(strtoul_n(SAMPLE, 5, NULL, 10) == 12312);
+		// assert(strtoul_n(SAMPLE, 6, NULL, 10) == 123123);
+		// assert(strtoul_n(SAMPLE, 20, NULL, 10) == LONG_MAX); // overflow
+		// assert(strncmp(buffer, SAMPLE, sizeof SAMPLE) == 0);
+	}
+
+	{
+		static const char SAMPLE[] = "&#62;П";
+		// do not convert symbols /, >, <, -, and ! to prevent xss
+		static const char INPUT[] = "&#;&#1055;&#62;&#1072;&#1074;&#1077;&#1083;&#62;"; // >
+		const size_t buf_len = 10; // "&#;" -- bad string
+		char not_null_term_buf[buf_len];
+		// assert(decode_html_entities_utf8_wo_unsafe_symbols_n(buffer, INPUT, 17, "/\0>\0<\0!\0-\0\0") == sizeof SAMPLE - 1);
+		size_t temp_buf_true_len = decode_html_entities_utf8_wo_unsafe_symbols_n(not_null_term_buf, INPUT, buf_len, "/\0>\0<\0!\0-\0\0");
+		printf("len = %d %.*s\n", temp_buf_true_len, temp_buf_true_len, not_null_term_buf);
+		not_null_term_buf[buf_len - 1] = 0;
+		// assert(strncmp(buffer, SAMPLE, sizeof SAMPLE) == 0);
+	}
 
 	fprintf(stdout, "All tests passed :-)\n");
 	return EXIT_SUCCESS;


### PR DESCRIPTION
First algo: prevent decode specific potentially dangerous anscii symbols e.g. `!', `<', `>', `/' and etc.
Second algo: decode specific len of <src> param to give the option to decode not-null terminated string(buffer)